### PR TITLE
Splits system (apt) and ROS (rosdep) update and intel wifi driver installation

### DIFF
--- a/subscripts/1Update/1Update_system.sh
+++ b/subscripts/1Update/1Update_system.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sudo apt -y update && sudo apt -y upgrade --with-new-pkgs --allow-downgrades
+
+exit 0

--- a/subscripts/1Update/2Update_system_and_baremetal_ROS.sh
+++ b/subscripts/1Update/2Update_system_and_baremetal_ROS.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+sudo apt -y update && rosdep update && sudo apt -y upgrade --with-new-pkgs --allow-downgrades
+
+source ~/.bashrc
+
+exit 0

--- a/subscripts/1Update_system.sh
+++ b/subscripts/1Update_system.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-sudo apt -y update && rosdep update && sudo apt -y upgrade --with-new-pkgs --allow-downgrades
-sudo apt install linux-modules-iwlwifi-$(uname -r) #Install correct wi-fi drivers - problem on new machines with ubuntu 20j
-sudo apt-mark hold linux-modules-iwlwifi-$(uname -r) #Hold the wifi driver at this version
-source ~/.bashrc
-exit 0
-
-

--- a/subscripts/2Install/7Install_Intel_WiFi_drivers.sh
+++ b/subscripts/2Install/7Install_Intel_WiFi_drivers.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Install correct WiFi drivers and holds them at this version - problem on new machines with ubuntu 20
+sudo apt install linux-modules-iwlwifi-$(uname -r)
+sudo apt-mark hold linux-modules-iwlwifi-$(uname -r)
+
+exit 0


### PR DESCRIPTION
When running ROS in docker we won't need to update it with baremetal rosdep command.

Intel driver might also not always be needed so it's split into a separate step.