### PR TITLE
Add support for disabling "Predictable Network Interface Names" on non-grub devices

### DIFF
--- a/subscripts/4Network/1Fix_network_interface_names.sh
+++ b/subscripts/4Network/1Fix_network_interface_names.sh
@@ -1,7 +1,22 @@
-#!/bin/bash 
+#!/bin/bash
 
-sudo sed -i 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"/g' /etc/default/grub
-sudo update-grub
+set -e
+
+if [[ -f /etc/default/grub ]]; then
+    # Device is using GRUB (e.g. Intel NUC)
+    sudo sed -i 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"/g' /etc/default/grub
+    sudo update-grub
+elif [[ -f /boot/extlinux/extlinux.conf ]]; then
+    # Device is using extlinux (e.g. NVIDIA Jetson)
+	if ! grep -q 'net.ifnames=0' /boot/extlinux/extlinux.conf; then
+		sudo cp /boot/extlinux/extlinux.conf /boot/extlinux/extlinux.conf.bak
+		sudo sed -i '/^[[:space:]]*APPEND / s/$/ net.ifnames=0 biosdevname=0/' /boot/extlinux/extlinux.conf
+	fi
+else
+	echo "Could not find a supported bootloader config."
+	echo "Expected /etc/default/grub or /boot/extlinux/extlinux.conf"
+	exit 1
+fi
 
 echo " "
 echo "Changes will be applied only after system reboot"

--- a/subscripts/4Network/1Fix_network_interface_names.sh
+++ b/subscripts/4Network/1Fix_network_interface_names.sh
@@ -3,19 +3,24 @@
 set -e
 
 if [[ -f /etc/default/grub ]]; then
-    # Device is using GRUB (e.g. Intel NUC)
-    sudo sed -i 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"/g' /etc/default/grub
-    sudo update-grub
+  # Device is using GRUB (e.g. Intel NUC)
+  if ! grep -q 'net\.ifnames=0' /etc/default/grub; then
+    sudo sed -i 's/^\(GRUB_CMDLINE_LINUX="[^"]*\)"/\1 net.ifnames=0"/' /etc/default/grub
+  fi
+  if ! grep -q 'biosdevname=0' /etc/default/grub; then
+    sudo sed -i 's/^\(GRUB_CMDLINE_LINUX="[^"]*\)"/\1 biosdevname=0"/' /etc/default/grub
+  fi
+  sudo update-grub
 elif [[ -f /boot/extlinux/extlinux.conf ]]; then
     # Device is using extlinux (e.g. NVIDIA Jetson)
 	sudo cp /boot/extlinux/extlinux.conf /boot/extlinux/extlinux.conf.bak
-	if grep -q 'net.ifnames=' /boot/extlinux/extlinux.conf; then
-		sudo sed -i 's/net.ifnames=[^[:space:]]*/net.ifnames=0/g' /boot/extlinux/extlinux.conf
+	if grep -q '^[[:space:]]*APPEND .*net\.ifnames=' /boot/extlinux/extlinux.conf; then
+		sudo sed -i '/^[[:space:]]*APPEND / s/net\.ifnames=[^[:space:]]*/net.ifnames=0/g' /boot/extlinux/extlinux.conf
 	else
 		sudo sed -i '/^[[:space:]]*APPEND / s/$/ net.ifnames=0/' /boot/extlinux/extlinux.conf
 	fi
-	if grep -q 'biosdevname=' /boot/extlinux/extlinux.conf; then
-		sudo sed -i 's/biosdevname=[^[:space:]]*/biosdevname=0/g' /boot/extlinux/extlinux.conf
+	if grep -q '^[[:space:]]*APPEND .*biosdevname=' /boot/extlinux/extlinux.conf; then
+		sudo sed -i '/^[[:space:]]*APPEND / s/biosdevname=[^[:space:]]*/biosdevname=0/g' /boot/extlinux/extlinux.conf
 	else
 		sudo sed -i '/^[[:space:]]*APPEND / s/$/ biosdevname=0/' /boot/extlinux/extlinux.conf
 	fi

--- a/subscripts/4Network/1Fix_network_interface_names.sh
+++ b/subscripts/4Network/1Fix_network_interface_names.sh
@@ -8,9 +8,16 @@ if [[ -f /etc/default/grub ]]; then
     sudo update-grub
 elif [[ -f /boot/extlinux/extlinux.conf ]]; then
     # Device is using extlinux (e.g. NVIDIA Jetson)
-	if ! grep -q 'net.ifnames=0' /boot/extlinux/extlinux.conf; then
-		sudo cp /boot/extlinux/extlinux.conf /boot/extlinux/extlinux.conf.bak
-		sudo sed -i '/^[[:space:]]*APPEND / s/$/ net.ifnames=0 biosdevname=0/' /boot/extlinux/extlinux.conf
+	sudo cp /boot/extlinux/extlinux.conf /boot/extlinux/extlinux.conf.bak
+	if grep -q 'net.ifnames=' /boot/extlinux/extlinux.conf; then
+		sudo sed -i 's/net.ifnames=[^[:space:]]*/net.ifnames=0/g' /boot/extlinux/extlinux.conf
+	else
+		sudo sed -i '/^[[:space:]]*APPEND / s/$/ net.ifnames=0/' /boot/extlinux/extlinux.conf
+	fi
+	if grep -q 'biosdevname=' /boot/extlinux/extlinux.conf; then
+		sudo sed -i 's/biosdevname=[^[:space:]]*/biosdevname=0/g' /boot/extlinux/extlinux.conf
+	else
+		sudo sed -i '/^[[:space:]]*APPEND / s/$/ biosdevname=0/' /boot/extlinux/extlinux.conf
 	fi
 else
 	echo "Could not find a supported bootloader config."

--- a/subscripts/4Network/1Fix_network_interface_names.sh
+++ b/subscripts/4Network/1Fix_network_interface_names.sh
@@ -13,6 +13,7 @@ if [[ -f /etc/default/grub ]]; then
   sudo update-grub
 elif [[ -f /boot/extlinux/extlinux.conf ]]; then
     # Device is using extlinux (e.g. NVIDIA Jetson)
+    echo "Creating backup of extlinux.conf at /boot/extlinux/extlinux.conf.bak"
 	sudo cp /boot/extlinux/extlinux.conf /boot/extlinux/extlinux.conf.bak
 	if grep -q '^[[:space:]]*APPEND .*net\.ifnames=' /boot/extlinux/extlinux.conf; then
 		sudo sed -i '/^[[:space:]]*APPEND / s/net\.ifnames=[^[:space:]]*/net.ifnames=0/g' /boot/extlinux/extlinux.conf


### PR DESCRIPTION
Jetsons are using extlinux instead of grub for booting, so the way to pass parameters for disabling predictable network interface names is different.

Note that OS directly from nvidia already has this disabled but the Seeed firmware has it enabled and this script has to be used.