### PR TITLE
Install nvidia container toolkit when installing docker

### DIFF
--- a/subscripts/2Install/6Install_Docker.sh
+++ b/subscripts/2Install/6Install_Docker.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Instructions for installing Docker: https://docs.docker.com/engine/install/ubuntu
+# Instructions for installing and configuring Nvidia Container Toolkit: https://docs.nvidia.com/jetson/orin-nano-devkit/user-guide/latest/setup_docker.html
+# Note that the instructions for the toolkit are wrong. The correct package to install is nvidia-container-toolkit, not nvidia-container, see https://github.com/fly4future/install_script/pull/18 for more info.
+
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl
 

--- a/subscripts/2Install/6Install_Docker.sh
+++ b/subscripts/2Install/6Install_Docker.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
 
-# https://docs.docker.com/engine/install/ubuntu/
+# Check if we're running on an NVIDIA Jetson device.
+# In that case we have to also install the NVIDIA Container Toolkit, 
+# which comprises of a few additional steps compared to a normal docker installation (https://docs.docker.com/engine/install/ubuntu/)
+# See https://docs.nvidia.com/jetson/agx-thor-devkit/user-guide/latest/setup_docker.html
+grep -q "NVIDIA Jetson" /proc/device-tree/model > /dev/null 2>&1
+is_jetson=$?
+
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl
+
+if [ "$is_jetson" -eq 0 ]; then
+    sudo apt-get install -y nvidia-container jq
+fi
 
 # Add Docker's official GPG key:
-sudo apt update
-sudo apt install -y ca-certificates curl
 sudo install -m 0755 -d /etc/apt/keyrings
 sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
 sudo chmod a+r /etc/apt/keyrings/docker.asc
@@ -24,4 +34,19 @@ sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin d
 sudo usermod -aG docker "$USER"
 
 sudo systemctl enable --now docker
+
+if [ "$is_jetson" -eq 0 ]; then
+    sudo nvidia-ctk runtime configure --runtime=docker
+    sudo systemctl daemon-reload 
+    sudo systemctl restart docker
+
+    sudo jq '. + {"default-runtime": "nvidia"}' /etc/docker/daemon.json | \
+    sudo tee /etc/docker/daemon.json.tmp && \
+    sudo mv /etc/docker/daemon.json.tmp /etc/docker/daemon.json
+fi
+
+echo
+echo "Docker installation complete. Please log out and log back in to apply the changes to your user group and be able to use the docker command without sudo."
+echo
+
 exit 0

--- a/subscripts/2Install/6Install_Docker.sh
+++ b/subscripts/2Install/6Install_Docker.sh
@@ -1,17 +1,11 @@
 #!/bin/bash
 
-# Check if we're running on an NVIDIA Jetson device.
-# In that case we have to also install the NVIDIA Container Toolkit, 
-# which comprises of a few additional steps compared to a normal docker installation (https://docs.docker.com/engine/install/ubuntu/)
-# See https://docs.nvidia.com/jetson/agx-thor-devkit/user-guide/latest/setup_docker.html
-grep -q "NVIDIA Jetson" /proc/device-tree/model > /dev/null 2>&1
-is_jetson=$?
-
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl
 
-if [ "$is_jetson" -eq 0 ]; then
-    sudo apt-get install -y nvidia-container jq
+# Check if we're running on an NVIDIA Jetson device.
+if grep -q "NVIDIA Jetson" /proc/device-tree/model > /dev/null 2>&1; then
+    sudo apt-get install -y nvidia-container-toolkit jq
 fi
 
 # Add Docker's official GPG key:
@@ -31,22 +25,24 @@ EOF
 
 sudo apt update
 sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-sudo usermod -aG docker "$USER"
-
 sudo systemctl enable --now docker
 
-if [ "$is_jetson" -eq 0 ]; then
+if grep -q "NVIDIA Jetson" /proc/device-tree/model > /dev/null 2>&1; then
+    echo "Configuring Docker to use NVIDIA Container Toolkit as the default runtime..."
     sudo nvidia-ctk runtime configure --runtime=docker
-    sudo systemctl daemon-reload 
+    sudo systemctl daemon-reload
     sudo systemctl restart docker
 
-    sudo jq '. + {"default-runtime": "nvidia"}' /etc/docker/daemon.json | \
-    sudo tee /etc/docker/daemon.json.tmp && \
+    sudo jq '. + {"default-runtime": "nvidia"}' /etc/docker/daemon.json | sudo tee /etc/docker/daemon.json.tmp
     sudo mv /etc/docker/daemon.json.tmp /etc/docker/daemon.json
+    sudo systemctl restart docker
 fi
 
-echo
-echo "Docker installation complete. Please log out and log back in to apply the changes to your user group and be able to use the docker command without sudo."
-echo
+echo "Add user $USER to docker group"
+sudo usermod -aG docker $USER
+
+echo ""
+echo "Docker installation complete. Please log out and log back in to apply the changes to your group and be able to use the docker command without sudo."
+echo ""
 
 exit 0


### PR DESCRIPTION
## Summary

Changed the docker install script to check if the device is a Jetson and in that case also install NVIDIA Container Toolkit 

## Impact

- no breaking changes, for non-jetson devices the behavior is exactly the same as before, for jetson devices now docker has support for CUDA

## Testing status

tested on a Jetson

**How to repeat tests**:
 run the "Install docker" script and then try running a container that needs GPU / CUDA support. Nvidia's documentation suggests the following container
```sh
docker run --rm -it \
    -v "$PWD":/workspace \
    -w /workspace \
    nvcr.io/nvidia/pytorch:25.08-py3
```

and running this in it
```sh
python3 <<'EOF'
import torch
print("PyTorch version:", torch.__version__)
print("CUDA available:", torch.cuda.is_available())
if torch.cuda.is_available():
    print("GPU name:", torch.cuda.get_device_name(0))
EOF
```

Do note that the container is very big.

## Additional comments about installation

The official installation steps for installing the toolkit are here: https://docs.nvidia.com/jetson/orin-nano-devkit/user-guide/latest/setup_docker.html.
Those instructions suggest installing `nvidia-container`, which is wrong, the correct package is `nvidia-container-toolkit`.

The `nvidia-container` package installs a systemd service `nv-install-docker`, which calls `/etc/systemd/nv-install-docker.sh` on start and `/etc/systemd/nv-install-docker-cleanup.sh` on end

The script `/etc/systemd/nv-install-docker.sh`, contains steps to:
1. "Remove conflicting packages": `docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc`
2. "Remove old docker packages": `docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras`
3. Reinstall docker

The script `nv-install-docker-cleanup.sh` will remove the install script, service and itself.

This means that if you follow the official installation steps from https://docs.nvidia.com/jetson/orin-nano-devkit/user-guide/latest/setup_docker.html you will install docker and then the `nv-install-docker` service will run (started by `nvidia-container` package).
This service will uninstall docker, reinstall it again and configure it to use the nvidia runtime.
Since there is no output notifying the user that this is happening the user will only notice that the `docker` command works at first, then it stops working for a while when the script is reinstalling in the background, and then it will start working again.

If you instead install `nvidia-container-toolkit`, you will only download the `nvidia-ctk` command and the runtime configuration needed, without the automatic install script.
